### PR TITLE
orpd-38: feat:delete outdated construction-data.csv and added endpoint support for details

### DIFF
--- a/orp/config/urls.py
+++ b/orp/config/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
     path("", orp_search_views.search, name="search"),
     # If we choose to have a start page with green button, this is it:
     # path("", core_views.home, name="home"),
-    path("details/", orp_search_views.details, name="details"),
+    path("details/<str:id>", orp_search_views.details, name="details"),
     path("healthcheck/", core_views.health_check, name="healthcheck"),
     path(
         "accessibility-statement/",

--- a/orp/orp_search/config.py
+++ b/orp/orp_search/config.py
@@ -14,6 +14,7 @@ class SearchDocumentConfig:
         offset=1,
         publisher_terms=None,
         sort_by=None,
+        id=None,
     ):
         """
         Initializes a new instance of the class.
@@ -32,6 +33,7 @@ class SearchDocumentConfig:
         self.offset = offset
         self.publisher_terms = publisher_terms
         self.sort_by = sort_by
+        self.id = id
 
     def validate(self):
         """

--- a/orp/orp_search/dummy_data.py
+++ b/orp/orp_search/dummy_data.py
@@ -1,3 +1,10 @@
+from io import StringIO
+
+import pandas as pd
+
+# flake8: noqa
+
+construction_data_csv = """
 id,title,identifier,publisher,language,format,description,date_issued,date_modified,date_valid,audience,coverage,subject,type,license,regulatory_topics,status,date_uploaded_to_orp,has_format,is_format_of,has_version,is_version_of,references,is_referenced_by,has_part,is_part_of,is_replaced_by,replaces,related_legislation
 Nt6Ft0Dt,Introduction to asbestos safety,https://www.hse.gov.uk/asbestos/introduction/index.htm,Health and Safety Executive,eng,HTML,"The guidance summarises what you should do to comply with the law, including:
 
@@ -7268,3 +7275,14 @@ Planning authorities",GB,"42110
 Planning
 Transport",,,,,,,,,,,,,"https://www.legislation.gov.uk/ukpga/2008/29
 https://www.legislation.gov.uk/uksi/2013/1883/article/3/made"
+"""
+
+
+def get_construction_data_as_dataframe():
+    # Use StringIO to convert the CSV string into a file-like object
+    csv_file_like_object = StringIO(construction_data_csv)
+
+    # Read the data into a pandas DataFrame
+    df = pd.read_csv(csv_file_like_object)
+
+    return df

--- a/orp/orp_search/public_gateway.py
+++ b/orp/orp_search/public_gateway.py
@@ -73,6 +73,15 @@ class PublicGateway:
         # removed from the final implementation
         if config.dummy:
             df = pd.read_csv("orp/orp_search/construction-data.csv")
+
+            if config.id:
+                # Fetch the record with the specified id
+                record = df[df["id"] == config.id].to_dict(orient="records")
+                if record:
+                    return record[0]  # Return the first matching record
+                else:
+                    return None  # Return None if no matching record is found
+
             search_terms_pattern = "|".join(title_search_terms)
 
             # Filter the DataFrame based on the search terms

--- a/orp/orp_search/public_gateway.py
+++ b/orp/orp_search/public_gateway.py
@@ -1,10 +1,10 @@
 import logging
 
-import pandas as pd
 import requests  # type: ignore
 
 from jinja2 import Template
 from orp_search.config import SearchDocumentConfig
+from orp_search.dummy_data import get_construction_data_as_dataframe
 
 logger = logging.getLogger(__name__)
 
@@ -72,9 +72,11 @@ class PublicGateway:
         # If the dummy flag is set, return dummy data. Ideally, this will be
         # removed from the final implementation
         if config.dummy:
-            df = pd.read_csv("orp/orp_search/construction-data.csv")
+            df = get_construction_data_as_dataframe()
 
             if config.id:
+                logger.info("using dummy data")
+
                 # Fetch the record with the specified id
                 record = df[df["id"] == config.id].to_dict(orient="records")
                 if record:

--- a/orp/orp_search/templates/details.html
+++ b/orp/orp_search/templates/details.html
@@ -11,24 +11,20 @@
         <a class="govuk-breadcrumbs__link" href="#">Search results</a>
       </li>
       <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="#">SR2015 No 39: use of waste in a deposit for recovery operations</a>
+        <a class="govuk-breadcrumbs__link" href="#">{{ result.title }}</a>
       </li>
     </ol>
   </nav>
   <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
     <div class="govuk-grid-row govuk-!-margin-bottom-4">
       <div class="govuk-grid-column-three-quarters">
-        <h1 class="govuk-heading-xl">SR2015 No 39: use of waste in a deposit for recovery operations</h1>
+        <h1 class="govuk-heading-xl">{{ result.title }}</h1>
       </div>
     </div>
     <div class="govuk-grid-row govuk-body">
       <div class="govuk-grid-column-three-quarters">
         <p class="govuk-body">
-          These standard rules allow you to store and use waste in a deposit for recovery activities involving
-          construction, reclamation, restoration or improvement of land other than by mobile plant.
-        </p>
-        <p class="govuk-body">
-          These standard rules are for the recovery of waste only and do not apply to any activities involving disposal.
+          {{ result.description }}
         </p>
         <h2 class="govuk-heading-m">Document details</h2>
         <dl class="govuk-summary-list">
@@ -37,7 +33,7 @@
               Link to document on publisher’s website
             </dt>
             <dd class="govuk-summary-list__value">
-              <a class="govuk-link" href="#">SR2015 No 39: use of waste in a deposit for recovery operations</a>
+              <a class="govuk-link" href="{{ result.identifier }}">{{ result.title }}</a>
             </dd>
           </div>
           <div class="govuk-summary-list__row">
@@ -45,7 +41,7 @@
               Document type
             </dt>
             <dd class="govuk-summary-list__value">
-              Guidance
+              {{ result.type }}
             </dd>
           </div>
           <div class="govuk-summary-list__row">
@@ -53,7 +49,7 @@
               Date published
             </dt>
             <dd class="govuk-summary-list__value">
-              2 February 2016
+              {{ result.date_issued }}
             </dd>
           </div>
           <div class="govuk-summary-list__row">
@@ -61,7 +57,7 @@
               Last updated
             </dt>
             <dd class="govuk-summary-list__value">
-              3 April 2019
+              {{ result.date_modified }}
             </dd>
           </div>
           <div class="govuk-summary-list__row">
@@ -69,25 +65,21 @@
               Published by
             </dt>
             <dd class="govuk-summary-list__value">
-              Environment Agency
+              {{ result.publisher }}
             </dd>
           </div>
         </dl>
         <h2 class="govuk-heading-m">Related content on legislation.gov.uk</h2>
         <p class="govuk-body">
-          <a class="govuk-link" href="#">Wildlife and Countryside Act 1981</a>
-        </p>
-        <p class="govuk-body">
-          <a class="govuk-link" href="#">Countryside and Rights of Way Act 2000</a>
+          <a class="govuk-link" href="#">{{ result.related_legislation }}</a>
         </p>
 
         <h2 class="govuk-heading-m">Regulatory topics</h2>
         <ul class="govuk-list orp-topics-list">
           <li class="govuk-body-s orp-secondary-text-colour">
-            Waste
-          </li>
-          <li class="govuk-body-s orp-secondary-text-colour">
-            Recycling
+              {% for topic in result.regulatory_topics %}
+                   <p>{{ topic }}</p>
+               {% endfor %}
           </li>
         </ul>
 

--- a/orp/orp_search/templates/orp.html
+++ b/orp/orp_search/templates/orp.html
@@ -243,7 +243,7 @@
             <div class="govuk-summary-list__row--no-border">
               <span class="govuk-caption-m">{{ result.document_type }}</span>
               <h2 class="govuk-heading-m">
-                <a href="/document/{{ result.id }}" class="govuk-link">
+                <a href="/details/{{ result.id }}" class="govuk-link">
                   {{result.title}}
                 </a>
               </h2>


### PR DESCRIPTION
Removed construction-data.csv from the orp_search directory. The file contained deprecated safety and regulation guidance for various construction topics, which are now available in updated formats elsewhere in the project.