### PR TITLE
feat:Add CSV download feature for search results

### DIFF
--- a/orp/config/urls.py
+++ b/orp/config/urls.py
@@ -12,6 +12,11 @@ urlpatterns = [
     path("", orp_search_views.search, name="search"),
     # If we choose to have a start page with green button, this is it:
     # path("", core_views.home, name="home"),
+    path(
+        "download_csv/",
+        orp_search_views.download_search_csv,
+        name="download_csv",
+    ),
     path("details/<str:id>", orp_search_views.details, name="details"),
     path("healthcheck/", core_views.health_check, name="healthcheck"),
     path(

--- a/orp/orp_search/templates/orp.html
+++ b/orp/orp_search/templates/orp.html
@@ -180,9 +180,23 @@
         </button>
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
         <p class="govuk-body">
-          <a href="#" class="govuk-link govuk-link--no-visited-state govuk-!-float-right">Download search results as CSV
+          <a id="download-csv-link" href="#" class="govuk-link govuk-link--no-visited-state govuk-!-float-right">Download search results as CSV
             file</a>
         </p>
+
+      <script>
+      // Function to get the current query parameters from the address bar
+      function getQueryParameters() {
+          return window.location.search;
+      }
+
+      document.addEventListener('DOMContentLoaded', function() {
+          var csvLink = document.getElementById('download-csv-link');
+          var queryParams = getQueryParameters();
+          var baseURL = '{% url "download_csv" %}';
+          csvLink.href = baseURL + queryParams;
+      });
+    </script>
       </form>
     </div>
 


### PR DESCRIPTION
Introduced a new view `download_search_csv` to generate search results as a CSV file. Updated the template to dynamically set the CSV download link with current query parameters. Adjusted the URL configuration to include the route for CSV download.