### PR TITLE
fix:add results_count to pagination context

### DIFF
--- a/orp/orp_search/public_gateway.py
+++ b/orp/orp_search/public_gateway.py
@@ -87,6 +87,7 @@ class PublicGateway:
         context["paginator"] = paginator
         context["is_paginated"] = paginator.num_pages > 1
         context["results"] = paginated_documents
+        context["results_count"] = len(paginated_documents)
         context["results_total_count"] = paginator.count
         context["results_page_total"] = paginator.num_pages
         context["current_page"] = config.offset


### PR DESCRIPTION
Included the total number of results in the pagination context by adding a count of the paginated documents. This ensures that the user interface can display the exact number of results on the current page.