### PR TITLE
temp:comment out unused legislation search logic in views.py

### DIFF
--- a/orp/orp_search/views.py
+++ b/orp/orp_search/views.py
@@ -240,17 +240,17 @@ def search(request: HttpRequest) -> HttpResponse:
     # Legislation search
     # If config.search_terms is empty then we don't need to
     # search for legislation
-    if not config.search_terms or "" in config.search_terms:
-        logger.info("no search terms provided")
-        return render(request, template_name="orp.html", context=context)
+    # if not config.search_terms or "" in config.search_terms:
+    #     logger.info("no search terms provided")
+    #     return render(request, template_name="orp.html", context=context)
 
-    if not config.document_types or "legislation" in config.document_types:
-        logger.info("searching for legislation: %s", config.search_terms)
-        legislation = Legislation()
-        legislation_results = legislation.search(config)
-        logger.info(f"legislation results: {legislation_results}")
-        context = legislation.finalise_results(
-            config, legislation_results, context
-        )
+    # if not config.document_types or "legislation" in config.document_types:
+    #     logger.info("searching for legislation: %s", config.search_terms)
+    #     legislation = Legislation()
+    #     legislation_results = legislation.search(config)
+    #     logger.info(f"legislation results: {legislation_results}")
+    #     context = legislation.finalise_results(
+    #         config, legislation_results, context
+    #     )
 
     return render(request, template_name="orp.html", context=context)


### PR DESCRIPTION
Disable the code block responsible for searching and processing legislation within the ORP search views. This helps to reduce unnecessary execution of code when no search terms or specific document types are provided.