### PR TITLE
update:URL paths and change DataResponseModel.identifier field

### DIFF
--- a/orp/config/urls.py
+++ b/orp/config/urls.py
@@ -92,7 +92,7 @@ class DataResponseViewSet(viewsets.ModelViewSet):
 
 
 class RebuildCacheViewSet(viewsets.ViewSet):
-    @action(detail=False, methods=["post"], url_path="rebuildcache")
+    @action(detail=False, methods=["post"], url_path="rebuild")
     def rebuild_cache(self, request, *args, **kwargs):
         from orp_search.legislation import Legislation
         from orp_search.public_gateway import PublicGateway
@@ -126,10 +126,10 @@ class RebuildCacheViewSet(viewsets.ViewSet):
 # Routers provide an easy way of automatically determining the URL conf.
 router = routers.DefaultRouter()
 router.register(r"v1", DataResponseViewSet, basename="search")
-router.register(r"v1", RebuildCacheViewSet, basename="rebuildcache")
+router.register(r"v1", RebuildCacheViewSet, basename="rebuild")
 
 urlpatterns = [
-    path("", include(router.urls)),
+    path("api/", include(router.urls)),
     path("", orp_search_views.search_react, name="search_react"),
     path("nojs/", orp_search_views.search_django, name="search_django"),
     # If we choose to have a start page with green button, this is it:

--- a/orp/orp_search/models.py
+++ b/orp/orp_search/models.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 class DataResponseModel(models.Model):
     title = models.TextField(null=True, blank=True)
-    identifier = models.URLField(unique=True)
+    identifier = models.TextField(null=True, blank=True)
     publisher = models.TextField(null=True, blank=True)
     language = models.TextField(null=True, blank=True)
     format = models.TextField(null=True, blank=True)


### PR DESCRIPTION
Modified the URL path for the RebuildCacheViewSet and adjusted the base URL to include "api/". Updated the DataResponseModel to change the identifier field from URLField to TextField to allow greater flexibility.