### PR TITLE
feat:add new Publishers API endpoint and updated response values

### DIFF
--- a/orp/orp_search/utils/paginate.py
+++ b/orp/orp_search/utils/paginate.py
@@ -71,6 +71,7 @@ def paginate(
                 "description": paginated_document.description,
                 "type": paginated_document.type,
                 "date_modified": paginated_document.date_modified,
+                "regulatory_topics": paginated_document.regulatory_topics,
             }
         )
 

--- a/orp/orp_search/utils/search.py
+++ b/orp/orp_search/utils/search.py
@@ -137,3 +137,13 @@ def search(context: dict, request: HttpRequest) -> dict:
     )
 
     return context
+
+
+def get_publisher_names():
+    publishers = DataResponseModel.objects.values("publisher").distinct()
+
+    publishers_list = []
+    for publisher in publishers:
+        publishers_list.append(publisher.publisher)
+
+    return publishers_list


### PR DESCRIPTION
Introduced a new `PublishersViewSet` with a `publishers` endpoint to retrieve distinct publisher names from the database. Updated URL routing to accommodate the new endpoint and added necessary imports and utility functions.