### PR TITLE
fix:handle None values in document_types and publisher_names

### DIFF
--- a/orp/orp_search/config.py
+++ b/orp/orp_search/config.py
@@ -25,13 +25,19 @@ class SearchDocumentConfig:
                         request.
         """
         self.search_query = search_query
-        self.document_types = [doc_type.lower() for doc_type in document_types]
+        self.document_types = (
+            None
+            if document_types is None
+            else [doc_type.lower() for doc_type in document_types]
+        )
         self.timeout = None if timeout is None else int(timeout)
         self.limit = limit
         self.offset = offset
-        self.publisher_names = [
-            pub_name.lower() for pub_name in publisher_names
-        ]
+        self.publisher_names = (
+            None
+            if publisher_names is None
+            else [pub_name.lower() for pub_name in publisher_names]
+        )
         self.sort_by = sort_by
         self.id = id
 


### PR DESCRIPTION
Previously, document_types and publisher_names were processed even if they were None, which caused errors. Now, these attributes are explicitly checked for None and handled appropriately to ensure stability and robustness in data processing.