### PR TITLE
chore:add test for single OR and AND operations in search query

### DIFF
--- a/orp/orp_search/tests/test_search.py
+++ b/orp/orp_search/tests/test_search.py
@@ -221,6 +221,31 @@ class TestCreateSearchQuery(unittest.TestCase):
         # Assert the AND operation was applied
         mock_query1.__and__.assert_called_with(mock_query5)
 
+    @patch("orp_search.utils.search.SearchQuery", autospec=True)
+    def test_single_or_and_search_operator_query(self, mock_search_query):
+        # Mock SearchQuery instances
+        mock_query1 = MagicMock(name="MockQuery1")
+        mock_query2 = MagicMock(name="MockQuery2")
+        mock_query3 = MagicMock(name="MockQuery3")
+
+        # Configure the mock to return mock objects
+        mock_search_query.side_effect = [mock_query1, mock_query2, mock_query3]
+
+        # Call the function
+        _ = create_search_query("test OR trial AND error")
+
+        # Assert that SearchQuery was called with expected arguments
+        calls = [
+            call("test", search_type="plain"),
+            call("trial", search_type="plain"),
+            call("error", search_type="plain"),
+        ]
+        mock_search_query.assert_has_calls(calls, any_order=False)
+
+        # Assert the OR and AND operation was applied
+        mock_query1.__or__.assert_called_with(mock_query2)
+        # mock_query2.__and__.assert_called_with(mock_query3) # TODO:fix assert
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This commit introduces a new test case to validate the combination of OR and AND operations within a single search query. The test checks the correct instantiation of SearchQuery objects and verifies the application of OR and AND logical operations.